### PR TITLE
Fix old 'prove' from erroring out on -j which was not included in, for example, 5.8.8 on perlbrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Example .travis.yml
     before_script:
       - coverage-setup
     script:
-      - prove -l -j$((SYSTEM_CORES + 1)) $(test-dirs)   # parallel testing
+      - prove -l $(test-jobs) $(test-dirs)   # parallel testing
     after_success:
       - coverage-report
 

--- a/init
+++ b/init
@@ -112,7 +112,10 @@ function test-files {
 }
 
 function test-jobs {
-  echo "$(( COVERAGE ? 1 : SYSTEM_CORES + 1))"
+  local prove_j="$(prove -V | perl -n -e '/TAP::Harness(?:::\S+)* v(.*?)\s/ && $1 >= 2.99_03 && print 1;')"
+  if [ "$prove_j" == 1 ] && [ "$COVERAGE" == 0 ]; then
+    echo "-j$((SYSTEM_CORES + 1))"
+  fi
 }
 
 function prove {
@@ -160,7 +163,7 @@ for arg; do
           else
             blib="-b"
           fi
-          prove $blib -r -s -j$(test-jobs) $(test-files) \
+          prove $blib -r -s $(test-jobs) $(test-files) \
             && coverage-report
         else
           command make "$@"
@@ -177,7 +180,7 @@ for arg; do
           else
             blib="-b"
           fi
-          prove $blib -r -s -j$(test-jobs) $(test-files) \
+          prove $blib -r -s $(test-jobs) $(test-files) \
             && coverage-report
           echo '#!/bin/sh' > Build
           chmod +x Build


### PR DESCRIPTION
Some of the older perl's that perlbrew fetches come with an older version of App::Prove. The readme example shows using "5.8.4" in combination with prove -l -j$((SYSTEM_CORES + 1)) which will give unknown options -j unknown option 3 unknown option 3 on travis-ci and fail. This patch checks for the version of prove, and uses $(test-jobs) to also pass the -j, such that if the version is below the threshold $(test-jobs) will be blank (complete with no -j flag). You probably want to change this so the user can still configure the number of cores they want to use instead of this PR using  a SYSTEMS_CORE + 1 default
