### PR TITLE
Use perl explicitly

### DIFF
--- a/bin/build-dist
+++ b/bin/build-dist
@@ -4,7 +4,7 @@ set -e
 [ -z "$HELPERS_ROOT" ] && export HELPERS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 source "$HELPERS_ROOT/lib/util.bash"
 
-perlbrew use $TRAVIS_PERL_VERSION
+perlbrew use "$TRAVIS_PERL_VERSION"
 
 BUILD_DIR=$1
 export PERL5LIB=

--- a/bin/cpan-install
+++ b/bin/cpan-install
@@ -2,7 +2,7 @@
 [ -z "$HELPERS_ROOT" ] && export HELPERS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 source "$HELPERS_ROOT/lib/util.bash"
 
-perlbrew use $TRAVIS_PERL_VERSION
+perlbrew use "$TRAVIS_PERL_VERSION"
 
 if [ -z "$MODERN_PERL" ]; then
   MODERN_PERL=perl


### PR DESCRIPTION
Hi. `bin/build-dist` and `bin/cpan-install` seem to have used a different perl from the one specified by [`TRAVIS_PERL_VERSION`](http://docs.travis-ci.com/user/languages/perl/#Environment-Variable), and thus, installing modules required to configure before `build-dist` didn't work as expected. This PR is to fix it.

A sample project and `.travis.yml` that I used to test is found at https://github.com/charsbar/sandbox . (The Makefile.PL there is actually a mock for the one in DBD::SQLite repository).
