### PR TITLE
Retain original HARNESS_PERL_SWITCHES if present

### DIFF
--- a/init
+++ b/init
@@ -77,7 +77,7 @@ function cpan-install {
 function coverage-setup {
   [ "$COVERAGE" -eq 0 ] && return
   cover -delete -silent
-  export HARNESS_PERL_SWITCHES='-MDevel::Cover=-ignore,^x?t/,-blib,0'
+  export HARNESS_PERL_SWITCHES="${HARNESS_PERL_SWITCHES}${HARNESS_PERL_SWITCHES:+ }"'-MDevel::Cover=-ignore,^x?t/,-blib,0'
 }
 
 function _coverage-opts {


### PR DESCRIPTION
Append coverage opts instead of overwriting in case the user has put HARNESS_PERL_SWITCHES into the travis env.