### PR TITLE
Echo test-files in Build heredoc to eliminate newlines

### DIFF
--- a/lib/auto.bash
+++ b/lib/auto.bash
@@ -31,6 +31,7 @@ function setup-auto {
         local coverage_cmd
         [ "$COVERAGE" -eq 0 ] || coverage_cmd="cover $@ $(_coverage-opts) || true"
         mv Build Build.run
+        # Echo test-files in the heredoc to eliminate the embedded newlines.
         cat > Build <<END
 #!/bin/bash
 set -e
@@ -38,7 +39,7 @@ set -e
 if [ "\$#" == "1" ] && [ "\$1" == "test" ]; then
   ./Build.run
   . "$HELPERS_ROOT/lib/prove.bash"
-  prove $blib -r -s -j$(test-jobs) $(test-files)
+  prove $blib -r -s -j$(test-jobs) $(echo `test-files`)
   $coverage_cmd
 else
   exec ./Build.run "\$@"


### PR DESCRIPTION
test-files uses find which contains newlines, but echoes the output
as a single string, which retains the newlines.
When used on the command line this is condensed, but when embedding in a
string (the heredoc) the newlines are preserved and the script is invalid.