### PR TITLE
Add a --travis-cache option that causes cpanm to be run without --skip-satisfied

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Commands
   * init
 
     Sets up the helper functions, and initializes environment variables.
-    Accepts two options:
+    Accepts three options:
       * --perl
         automatically runs the build-perl command for you
 
@@ -190,6 +190,12 @@ Commands
         commands as appropriate to do a full build and test.  If this option is
         used, none of the other build phases should be customized, and none of
         the commands should be used aside from cpan-install.
+
+      * --always-upgrade-modules
+        The `cpanm` command will be run without the `--skip-satisfied`
+        option. If you are using the Travis caching, you will want to add this
+        flag so that your local lib does not get progressively more out of
+        date over time.
 
   * build-perl
 
@@ -216,10 +222,13 @@ Commands
     the --deps flag can be given to install all dependencies of the current
     dist.
 
-    Also accepts the --coverage option.  If the COVERAGE environment variable
-    is set, this will attempt to install Devel::Cover and
+    This command accepts the --coverage option.  If the COVERAGE environment
+    variable is set, this will attempt to install Devel::Cover and
     Devel::Cover::Report::Coveralls.  If the environment variable is not set,
     does nothing.
+
+    Finally, you can pass --update-prereqs to make this script run without
+    passing `--skip-satisfied` to `cpanm`.
 
   * tests-dirs
 

--- a/bin/cpan-install
+++ b/bin/cpan-install
@@ -172,6 +172,15 @@ function install-items {
   local arg
   for arg in "$@"; do
     case $arg in
+        # If Travis caching is enabled and we pass --skip-satisfied, then we
+        # will _never_ update the installed modules in the cache. The caches
+        # don't expire unless you delete them manually, meaning that people
+        # could end up caching modules that are months or years out of date.
+      --update-prereqs)
+        if [[ $INSTALL_CMD =~ "--skip-satisfied" ]]; then
+          INSTALL_CMD="${INSTALL_CMD/--skip-satisfied/}"
+        fi
+      ;;
       --toolchain)
         install-module $($HELPERS_ROOT/bin/modules-for-local-lib toolchain)
       ;;

--- a/init
+++ b/init
@@ -73,7 +73,7 @@ function build-perl {
 }
 
 function cpan-install {
-  $HELPERS_ROOT/bin/cpan-install "$@"
+  $HELPERS_ROOT/bin/cpan-install "$CPAN_INSTALL_FLAGS" "$@"
 }
 
 function coverage-setup {
@@ -158,11 +158,13 @@ echo "Perl Travis Helpers: $(git --git-dir="$HELPERS_ROOT/.git" describe --all -
 for arg; do
   case "$arg" in
     --auto)
-      setup-auto
+      AUTO=1
     ;;
     --perl)
-      build-perl
-      perl -V
+      PERL=1
+    ;;
+    --always-upgrade-modules)
+      CPAN_INSTALL_FLAGS="--update-prereqs"
     ;;
     --debug)
       export HELPERS_DEBUG=1
@@ -173,5 +175,12 @@ for arg; do
     ;;
   esac
 done
+
+if [ -n "$AUTO" ]; then
+  setup-auto
+elif [ -n "$PERL" ]; then
+  build-perl
+  perl -V
+fi
 
 # vim: ft=sh


### PR DESCRIPTION
I'm not really set on this particular argument name or this implementation, but it does seem to work. See https://travis-ci.org/autarch/Specio/builds/136857643 for a build where this flag was passed.
