### PR TITLE
exclude xt/release from test-files unless release testing

### DIFF
--- a/init
+++ b/init
@@ -119,7 +119,13 @@ function test-dirs {
 }
 
 function test-files {
-  local file_list="$(find $(test-dirs) -name '*.t' | sort)"
+  local file_list=""
+  if [ "$RELEASE_TESTING" -ne 0 ]; then
+    file_list="$(find $(test-dirs) -name '*.t' | sort)"
+  else
+    file_list="$(find $(test-dirs) -name '*.t' ! -path 'xt/release/*' | sort)"
+  fi
+
   local IFS=$'\n'
   local -a files=($file_list)
   if [ -n "$TEST_PARTITION" ]; then


### PR DESCRIPTION
This is an alternate to #49, as discussed on IRC (#distzilla on magnet)

I wanted to have a variable containing extra `! -path` args to pass, but I got sick of fighting with bash, so this is what you get.  I think it's sufficient.