### PR TITLE
Use `./` prefix for do for Module::Build dists

### DIFF
--- a/bin/build-dist
+++ b/bin/build-dist
@@ -57,7 +57,7 @@ elif [ -e 'Build.PL' ]; then
   auto-install "perl Build.PL" < /dev/null
   ./Build manifest
   ./Build distdir
-  DIST_DIR=$(perl -e'my $d = (do "_build/build_params")->[2]; print "$d->{dist_name}-$d->{dist_version}\n"')
+  DIST_DIR=$(perl -e'my $d = (do "./_build/build_params")->[2]; print "$d->{dist_name}-$d->{dist_version}\n"')
   mv "$DIST_DIR" "$BUILD_DIR"
 elif [ -e 'Makefile.PL' ]; then
   if grep -q 'Module::Install' 'Makefile.PL'; then


### PR DESCRIPTION
This is needed for the removal of . from `@INC` in Perl 5.26.

An example of how this failure appears can be seen in the difference between
- what is currently on master [53.1 (perl 5.26.0)](https://travis-ci.org/zmughal/bioperl-live/jobs/263398818): **build failure** with the following message
  
  ```
  Creating BioPerl-1.007001
  do "_build/build_params" failed, '.' is no longer in @INC; did you mean do "./_build/build_params"? at -e line 1.
  Can't use an undefined value as an ARRAY reference at -e line 1.
  The command "build-dist" failed and exited with 2 during .
  Your build has been stopped.
  ```
- the result of the changes on this branch: [54.1 (perl 5.26.0)](https://travis-ci.org/zmughal/bioperl-live/jobs/263398851): **successful build**.

CC: <https://github.com/bioperl/bioperl-live/issues/240>.