### PR TITLE
Document coverage report

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The simple `.travis.yml` listed above is roughly equivalent to:
       - cd $BUILD_DIR             # $BUILD_DIR is set by the build-dist command
     install:
       - cpan-install --deps       # installs prereqs, including recommends
-      - cpan-install --coverage   # installs converage prereqs, if enabled
+      - cpan-install --coverage   # installs coverage prereqs, if enabled
     before_script:
       - coverage-setup
     script:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ Example Simple .travis.yml
     matrix:
       include:
         - perl: 5.18
-          env: COVERAGE=1   # enables coverage+coveralls reporting
+          env: COVERAGE=1   # enables coverage reporting (coveralls by default),
+                            # or COVERAGE=report_name to use a specific report
+                            # module
       allow_failures:
         - perl: blead       # ignore failures for blead perl
     sudo: false             # faster builds as long as you don't need sudo access
@@ -87,10 +89,11 @@ There are various environment variables that will control how a build is done.
 
   * `COVERAGE`
 
-    If true, coverage will be reported after running tests.  Coverage results
-    will also be submitted to [Coveralls](https://coveralls.io/).  If false,
-    the `coverage-setup`, `coverage-report`, and `cpan-install --coverage`
-    commands will be no-ops.
+    If true, coverage will be reported after running tests. When value is
+    1 coverage results will be submitted to [Coveralls](https://coveralls.io/).
+    Otherwise the value is going to be used a Devel::Cover report module name.
+    If false, the `coverage-setup`, `coverage-report`, and `cpan-install
+    --coverage` commands will be no-ops.
 
     Defaults to false.
 
@@ -224,8 +227,8 @@ Commands
 
     This command accepts the --coverage option.  If the COVERAGE environment
     variable is set, this will attempt to install Devel::Cover and
-    Devel::Cover::Report::Coveralls.  If the environment variable is not set,
-    does nothing.
+    Devel::Cover::Report::$COVERAGE (Coveralls when value is 1).  If the
+    environment variable is not set, does nothing.
 
     Finally, you can pass --update-prereqs to make this script run without
     passing `--skip-satisfied` to `cpanm`.
@@ -255,9 +258,9 @@ Commands
 
   * coverage-report
 
-    Outputs a coverage report.  If Devel::Cover::Report::Coveralls is
-    available, it will send the report to Coveralls.  Does nothing if
-    `COVERAGE` is false.
+    Outputs a coverage report.  If Devel::Cover::Report::$COVERAGE is available,
+    it will use the corresponding report module. When set to 1 default module
+    name is Coveralls. Does nothing if `COVERAGE` is false.
 
   * local-lib
 


### PR DESCRIPTION
Even though `COVERAGE` variable can be set to any Devel::Cover report module it is not documented. This PR improves the documentation.