### PR TITLE
Add support for Perl 5.5.x versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: perl
 perl:
+  - "5.5.3"       # very ancient
   - "5.6.2"       # ancient
   - "5.8.8"       # common, prebuilt version
   - "5.8.8-thr"   # various build flags

--- a/bin/build-perl
+++ b/bin/build-perl
@@ -45,6 +45,17 @@ function perlbrew_build {
   [[ "${perl_version}-" =~ '-qm-' ]] && brewopts+=(-Dusequadmath)
   [[ "${perl_version}-" =~ '-ld-' ]] && brewopts+=(-Duselongdouble)
 
+  if [[ "$minor_version" =~ ^[0-5]$ ]]; then
+    # Perl versions prior to 5.6 have version format 5.00X_YY
+    rel_version="$(sed -n -E -e's/^5\.[0-9]\.//p' <<< "$brewver")"
+    [ "$rel_version" = "0" ] && rel_version=""
+    [[ "$rel_version" =~ ^[0-9]$ ]] && rel_version="0$rel_version"
+    [ -n "$rel_version" ] && rel_version="_$rel_version"
+    brewver="5.00${minor_version}${rel_version}"
+    # perlbrew does not call patchperl correctly, upstream patch: https://github.com/gugod/App-perlbrew/pull/674
+    sed 's/push @preconfigure_commands, \$patchperl/push @preconfigure_commands, "chmod -R +w .", \$patchperl/' -i `which perlbrew`
+  fi
+
   printf "Building Perl %s ..." "${perl_version}"
   run-with-progress perlbrew install --as "$perl_version" "${brewopts[@]}" "$brewver"
 

--- a/bin/cpan-config
+++ b/bin/cpan-config
@@ -1,6 +1,6 @@
 #!/usr/bin/env perl
 use strict;
-use warnings;
+BEGIN { $^W = 1 }
 
 my %myconfig;
 BEGIN {
@@ -19,7 +19,6 @@ use CPAN ();
 use ExtUtils::MakeMaker ();
 use File::Basename qw(dirname);
 use Cwd;
-use File::Spec;
 
 my $helper_root = $ENV{HELPERS_ROOT} ||= Cwd::abs_path(dirname(__FILE__).'/..');
 
@@ -39,12 +38,12 @@ my %config = (
 
 {
   $CPAN::Frontend = 'FakeFrontEnd';
-  no warnings 'redefine';
+  BEGIN { eval { require warnings; 'warnings'->unimport('redefine') } }
   local *ExtUtils::MakeMaker::prompt = sub ($;$) {
     $_[0] =~ /manual configuration/ ? 'no' : $_[1];
   };
-  open STDOUT, '>', File::Spec->devnull;
-  open STDERR, '>', File::Spec->devnull;
+  open STDOUT, '>/dev/null';
+  open STDERR, '>/dev/null';
   $CPAN::Config = { %config };
   eval { CPAN::Config->load };
   $CPAN::Config = { %config };

--- a/bin/cpan-prereqs
+++ b/bin/cpan-prereqs
@@ -1,9 +1,8 @@
 #!/usr/bin/env perl
 use strict;
-use warnings;
+BEGIN { $^W = 1 }
 use CPAN ();
 use Cwd;
-use File::Spec;
 
 {
   package FakeFrontEnd;
@@ -30,9 +29,9 @@ my $err;
   open OLDOUT, '>&STDOUT' or die "Can't dup STDOUT: $!";
   open OLDERR, '>&STDERR' or die "Can't dup STDERR: $!";
   open OLDIN,  '<&STDIN'  or die "Can't dup STDIN: $!";
-  open STDOUT, '>', File::Spec->devnull or die "Can't redirect STDOUT: $!";
-  open STDERR, '>', File::Spec->devnull or die "Can't redirect STDERR: $!";
-  open STDIN,  '<', File::Spec->devnull or die "Can't redirect STDIN: $!";
+  open STDOUT, '>/dev/null' or die "Can't redirect STDOUT: $!";
+  open STDERR, '>/dev/null' or die "Can't redirect STDERR: $!";
+  open STDIN,  '</dev/null' or die "Can't redirect STDIN: $!";
 
   $dist->{build_dir} = '.';
   eval {
@@ -58,7 +57,7 @@ my @prereqs = $dist->can('unsat_prereq') ? do {
       if $phase =~ /opt/;
     my $p = $r->{$phase};
     for my $req (keys %$p) {
-      no warnings;
+      $^W = 0;
       if ($p->{$req} > $r{$req} || $p->{$req} gt $r{$req}) {
         $r{$req} = $p->{$req};
       }

--- a/t/eumm/Makefile.PL
+++ b/t/eumm/Makefile.PL
@@ -1,5 +1,5 @@
 use strict;
-use warnings;
+BEGIN { $^W = 1 }
 use ExtUtils::MakeMaker;
 
 WriteMakefile(

--- a/t/eumm/t/prereq.t
+++ b/t/eumm/t/prereq.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Test::More tests => 1 + ($] >= 5.010 ? 9 : 0);

--- a/t/local-lib.t
+++ b/t/local-lib.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Test::More tests => 3;

--- a/t/mb/t/prereqs.t
+++ b/t/mb/t/prereqs.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Test::More tests => 1;

--- a/t/mb/t/second-file.t
+++ b/t/mb/t/second-file.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Test::More tests => 1;

--- a/t/perl-version.t
+++ b/t/perl-version.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Config;

--- a/t/pre-built.t
+++ b/t/pre-built.t
@@ -1,3 +1,4 @@
+BEGIN { do { print "1..0 # SKIP\n"; exit } if $] lt '5.006' }
 use strict;
 use warnings;
 use Test::More tests => 1;


### PR DESCRIPTION
Travis tests with 5.5.3 version passes with changes in these pull requests:
https://github.com/travis-perl/TravisCI-Helpers-InstallerTest/pull/1
https://github.com/travis-perl/TravisCI-Helpers-InstallerTest/pull/2